### PR TITLE
optional Objective-C support (default off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ other|%d artists
 #### String Array: (Android)
 ["Monday", "Tuesday", "Wednesday"]
 
+## iOS specifics
+
+In order to support Objective-C, the plugin provides the `support_objc` argument, which is default `false`.  
+Therefore, if you need Objective-C support pass `support_objc: true`.
+
 ## Example
 
 ```ruby


### PR DESCRIPTION
This PR is based on the previous change to enable Objective-C interoperability. Many projects are pure-swift and the changes are not needed for them. Therefore, I added a `support_objc` parameter to explicitly enable the support. (default off is coordinated with the maintainer @mariohahn)